### PR TITLE
CRM-20981 - CRM_Civicase_Page_CaseAngular - Call `useApp()` helper

### DIFF
--- a/CRM/Civicase/Page/CaseAngular.php
+++ b/CRM/Civicase/Page/CaseAngular.php
@@ -18,21 +18,12 @@ class CRM_Civicase_Page_CaseAngular extends \CRM_Core_Page {
   public function run() {
     $loader = new \Civi\Angular\AngularLoader();
     $loader->setPageName('civicrm/case/a');
-    $loader->setModules(array('crmApp', 'civicase'));
-    $loader->load();
-    \Civi::resources()->addSetting(array(
-      'crmApp' => array(
-        'defaultRoute' => '/case/list',
-      ),
+    $loader->setModules(array('civicase'));
+    $loader->useApp(array(
+      'defaultRoute' => '/case/list',
     ));
+    $loader->load();
     return parent::run();
-  }
-
-  /**
-   * @inheritdoc
-   */
-  public function getTemplateFileName() {
-    return 'Civi/Angular/Page/Main.tpl';
   }
 
 }

--- a/templates/CRM/Civicase/Page/CaseAngular.tpl
+++ b/templates/CRM/Civicase/Page/CaseAngular.tpl
@@ -1,0 +1,1 @@
+{* placeholder *}


### PR DESCRIPTION
Overview
--------
`CRM_Civicase_Page_CaseAngular` demonstrates how to use `AngularLoader` to setup a custom base-page.  Based on discussion with @GinkgoFJG about updating CiviVolunteer to use `AngularLoader`, we wanted to make the example simpler to imitate.

Before
------
The example does three separate things to setup `crmApp`.

After
-----
The example uses the new helper function `useApp(...)` provided by https://github.com/civicrm/civicrm-core/pull/10783.

Comments
--------
 * This is not critical.
 * Do not merge until https://github.com/civicrm/civicrm-core/pull/10783 is merged.