### PR TITLE
ViewPeople - Fix crash

### DIFF
--- a/ang/civicase/ViewPeople.js
+++ b/ang/civicase/ViewPeople.js
@@ -34,7 +34,7 @@
       role.description = (role.manager ? (ts('Case Manager.') + ' ') : '') + (relType.description || '');
       role.relationship_type_id = relType.id;
     }
-    $scope.allRoles = _.each(_.cloneDeep(item.definition.caseRoles), formatRole);
+    $scope.allRoles = [];
 
     var getSelectedContacts = $scope.getSelectedContacts = function(tab, onlyChecked) {
       var idField = (tab === 'roles' ? 'contact_id' : 'id');
@@ -48,6 +48,9 @@
     };
 
     var getCaseRoles = $scope.getCaseRoles = function() {
+      if ($scope.item && $scope.item.definition && $scope.item.definition.caseRoles) {
+        $scope.allRoles = _.each(_.cloneDeep($scope.item.definition.caseRoles), formatRole);
+      }
       var caseRoles = $scope.rolesAlphaFilter ? [] : _.cloneDeep($scope.allRoles),
         allRoles = _.cloneDeep($scope.allRoles),
         selected = getSelectedContacts('roles', true);


### PR DESCRIPTION
There was a crash reported when opening this URL:

```
http://civicase.ccuptest.co.uk/civicrm/case/a/#/case/list?sf=contact_id.sort_name&sd=ASC&focus=1&cf=%7B%7D&caseId=17&tab=people&sx=0&cpn=1&cps=25&peopleTab=roles
```

The original report included an error message `TypeError: Cannot read
property 'caseRoles' of undefined` (chrome).  With the current code, I
didn't get this message, but I did see a similar `item.definition is
undefined` (Firefox) when attempting to build `allRoles`.

I don't entirely understand the context (e.g.  why does the list of
`allRoles` depend on `$scope.item`).  However, given that it does, the
problem is most likely that that `$scope.item` hasn't been initialized yet.
Generally, it's not safe to read data from `$scope` immediately during setup
of the controller; it's safer to `$watch()` for when the data becomes
available.

As it happens, there's a watch: `$scope.$watch('item', getCaseRoles, true);`
which will fire `getCaseRoles` whenever `item` is populated.  We just wait
to populate `allRoles` then.