### PR TITLE
HW-379: Styled Next milestones and recent communication on dashboard

### DIFF
--- a/ang/civicase/ActivityCard.html
+++ b/ang/civicase/ActivityCard.html
@@ -1,4 +1,4 @@
-<div
+<div style="border-left-color: {{ activity.color }}; border-right-color: {{ activity.color }};" 
   class="act-feed-item activity-card act-category-{{ activity.category.join(' act-category-') || 'none' }} {{ activity.status_css }}"
   ng-class="{'is-completed': activity.is_completed, 'is-incomplete': !activity.is_completed, 'activity-overdue': activity.is_overdue}"
   ng-click="viewInPopup($event, activity)"

--- a/ang/civicase/DashboardCtrl.html
+++ b/ang/civicase/DashboardCtrl.html
@@ -15,40 +15,67 @@
 
       <div class="panel panel-default" ng-include="'~/civicase/DashboardSummary.html'"></div>
 
-      <div class="panel panel-default">
-        <div class="panel-header">{{ ts('Next Milestones') }}</div>
-        <div class="panel-body">
-          <div class="activity-timeline">
-            <ul class="list-group act-feed-list-group" ng-if="dashboardActivities.nextMilestones.length">
-              <li class="list-group-item" ng-repeat="activity in dashboardActivities.nextMilestones">
-                <div
-                  case-activity-card="activity"
-                  refresh-callback="refresh"
-                  edit-activity-url="editActivityUrl"
-                ></div>
-              </li>
-            </ul>
-            <div class="civicase-panel-empty" ng-if="!dashboardActivities.nextMilestones.length">
-              {{ ts('No upcoming milestones.') }}
+      <div class="row dashboard-case-wrapper">
+        <div class="col-md-4">
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h3 class="panel-title">{{ ts('Next Milestones') }}
+                <span class="badge badge-danger">{{dashboardActivities.nextMilestones.length}}</span>
+                <a href="#" class="pull-right">(see all)</a>
+              </h3>
+
+            </div>
+            <div class="panel-body">
+              <div class="activity-timeline">
+                <ul class="list-group act-feed-list-group" ng-if="dashboardActivities.nextMilestones.length">
+                  <li class="list-group-item" ng-repeat="activity in dashboardActivities.nextMilestones">
+                    <div
+                      case-activity-card="activity"
+                      refresh-callback="refresh"
+                      edit-activity-url="editActivityUrl"
+                    ></div>
+                  </li>
+                </ul>
+                <div class="civicase-panel-empty" ng-if="!dashboardActivities.nextMilestones.length">
+                  {{ ts('No upcoming milestones.') }}
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h3 class="panel-title">{{ ts('Recent Communications') }}
+                <span class="badge badge-primary">{{dashboardActivities.recentCommunication.length}}</span>
+                <a href="#" class="pull-right">(see all)</a>
+              </h3>
+            </div>
+            <div class="panel-body">
+              <div class="activity-timeline">
+                <ul class="list-group act-feed-list-group" ng-if="dashboardActivities.recentCommunication.length">
+                  <li class="list-group-item" ng-repeat="activity in dashboardActivities.recentCommunication">
+                    <div
+                      case-activity-card="activity"
+                      refresh-callback="refresh"
+                      edit-activity-url="editActivityUrl"
+                    ></div>
+                  </li>
+                </ul>
+                <div class="civicase-panel-empty" ng-if="!dashboardActivities.recentCommunication.length">
+                  {{ ts('No completed communications.') }}
+                </div>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div class="panel panel-default">
-        <div class="panel-header">{{ ts('Recent Communications') }}</div>
-        <div class="panel-body">
-          <div class="activity-timeline">
-            <ul class="list-group act-feed-list-group" ng-if="dashboardActivities.recentCommunication.length">
-              <li class="list-group-item" ng-repeat="activity in dashboardActivities.recentCommunication">
-                <div
-                  case-activity-card="activity"
-                  refresh-callback="refresh"
-                  edit-activity-url="editActivityUrl"
-                ></div>
-              </li>
-            </ul>
-            <div class="civicase-panel-empty" ng-if="!dashboardActivities.recentCommunication.length">
-              {{ ts('No completed communications.') }}
+        <div class="col-md-8">
+          <div class="panel panel-default">
+            <div class="panel-heading">
+              <h3 class="panel-title">{{ ts('Recent Cases') }}
+                <a href="#" class="pull-right">(view all in caselist)</a>
+              </h3>
+            </div>
+            <div class="panel-body">
+              FIXME: Need to show Recent Cases
             </div>
           </div>
         </div>

--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -191,3 +191,23 @@
   top: 15%;
   width: 1px;
 }
+#bootstrap-theme .dashboard-case-wrapper .panel-default>.panel-heading .badge.badge-primary {
+  background-color: #8EC68A;
+}
+#bootstrap-theme .dashboard-case-wrapper .panel-default>.panel-heading .badge.badge-danger {
+  background-color: #E6807F;
+}
+#bootstrap-theme .dashboard-case-wrapper .act-feed-item {
+  border-radius: 2px;
+  margin: 5px 0px;
+}
+#bootstrap-theme .dashboard-case-wrapper .act-feed-item.activity-overdue {
+  border-left-color: #E6807F !important;
+  border-right-color: #E6807F !important;
+}
+#bootstrap-theme .dashboard-case-wrapper .panel-default>.panel-heading a {
+  color: #42AFCB;
+  font-size: 13px;
+  font-weight: normal;
+  margin-top: 3px;
+}


### PR DESCRIPTION
**Before:**
![before](https://user-images.githubusercontent.com/26058635/30110980-a95a6bf4-9329-11e7-816a-75043cd183b6.png)

**After:**
![after](https://user-images.githubusercontent.com/26058635/30110979-a949b034-9329-11e7-8d1f-1a71d53e6483.png)

**Note:**
1. Need to add recent cases section - marked as FIXME for now
2. Need to add link related to specific section for each title (i.e. see all, view all in caselist)
3. Need to separate markup for activity card for recent communication. (@colemanw, I have pointed the section in design for your reference. You can just call different template, I can change markup afterwards)