### PR TITLE
HW-393: Styling case custom field inline styles

### DIFF
--- a/ang/civicase/CaseViewCustomData.html
+++ b/ang/civicase/CaseViewCustomData.html
@@ -1,9 +1,6 @@
 <div class="crm-collapsible" ng-class="::{ collapsed: customGroup.collapse_display }">
   <h3 class="collapsible-title" ng-click="customGroup.collapse_display = !customGroup.collapse_display">{{ ::customGroup.title }}</h3>
-  <!-- FIXME: This needs to have proper logic on form open/close in ng-style -->
-  <div 
-  ng-style="{ display: customGroup.collapse_display ? 'none' : 'block' }"
-  civicase-edit-custom-data>
+  <div civicase-edit-custom-data>
     <div ng-repeat="field in customGroup.fields">
       <strong>{{ field.label }}:</strong>
       {{ field.value.display }}

--- a/ang/civicase/CaseViewCustomData.html
+++ b/ang/civicase/CaseViewCustomData.html
@@ -1,6 +1,9 @@
 <div class="crm-collapsible" ng-class="::{ collapsed: customGroup.collapse_display }">
   <h3 class="collapsible-title" ng-click="customGroup.collapse_display = !customGroup.collapse_display">{{ ::customGroup.title }}</h3>
-  <div civicase-edit-custom-data>
+  <!-- FIXME: This needs to have proper logic on form open/close in ng-style -->
+  <div 
+  ng-style="{ display: customGroup.collapse_display ? 'none' : 'block' }"
+  civicase-edit-custom-data>
     <div ng-repeat="field in customGroup.fields">
       <strong>{{ field.label }}:</strong>
       {{ field.value.display }}

--- a/css/caseView.css
+++ b/css/caseView.css
@@ -230,6 +230,37 @@
   padding: 0;
   top: 0;
 }
+#bootstrap-theme .crm-case-custom-form-block .crm-accordion-body {
+  padding: 5px;
+}
+#bootstrap-theme .crm-case-custom-form-block td.label {
+  display: table-cell;
+  padding-top: 7.5px;
+  text-align: left;
+  vertical-align: top;
+}
+#bootstrap-theme .crm-case-custom-form-block .select2-choice .select2-arrow {
+  background: none;
+  padding: 0;
+  width: 26px;
+}
+#bootstrap-theme .crm-case-custom-form-block .select2-container .select2-choices {
+  margin-bottom: 0;
+}
+#bootstrap-theme .crm-case-custom-form-block input.crm-form-date {
+  display: inline-block;
+}
+#bootstrap-theme .crm-case-custom-form-block .crm-form-text {
+  max-width: 230px;
+}
+#bootstrap-theme .crm-case-custom-form-block .crm-form-textarea {
+  height: 80px;
+  max-width: 230px;
+}
+#bootstrap-theme .crm-case-custom-form-block .crm-button-type-cancel input:hover {
+  color: #FFF !important;
+}
+
 #bootstrap-theme .select2-container.select2-dropdown-open,
 #bootstrap-theme .select2-container.select2-container-active .select2-choice, 
 #bootstrap-theme .select2-container.select2-container-active .select2-choices {
@@ -379,4 +410,7 @@
   opacity: 0.6;
   line-height: 18px;
   margin-top: 6px;
+}
+#bootstrap-theme .collapsible-title {
+  padding: 5px 15px;
 }


### PR DESCRIPTION
**Before:**

_1._
<img width="430" alt="screen shot 2017-09-27 at 11 07 54" src="https://user-images.githubusercontent.com/26058635/30951987-5faf0e1c-a443-11e7-84c3-bde89999ae99.png">

_2._
<img width="468" alt="screen shot 2017-09-27 at 11 11 10" src="https://user-images.githubusercontent.com/26058635/30951989-617ddf02-a443-11e7-99d0-d205d67851fe.png">

_3._
<img width="553" alt="screen shot 2017-09-27 at 11 15 46" src="https://user-images.githubusercontent.com/26058635/30951994-63847fe0-a443-11e7-94be-9b04e259e8c7.png">

**After:**

_1._
![after-1](https://user-images.githubusercontent.com/26058635/30952002-70c5b82c-a443-11e7-9806-a5bbed122c9c.png)

_2._
![after-2](https://user-images.githubusercontent.com/26058635/30952004-7300e7e2-a443-11e7-9802-61a679589bf3.png)

_3._
![after-3](https://user-images.githubusercontent.com/26058635/30952013-7b5824d2-a443-11e7-8327-9ed43c3df88a.png)

**Notes:**
@colemanw You will need to see below 2 points in this to fix this accurately

1. Custom field collapse is not accurate, we will need to have some accurate and right logic. I have comment for that.
2. As per below image, deselecting a radio button option, takes user out of case detail and gets him on case list page. <img width="553" alt="screen shot 2017-09-27 at 11 15 46" src="https://user-images.githubusercontent.com/26058635/30952141-4180a92c-a444-11e7-851a-92d34a746df2.png">
