### PR TITLE
HW-409: Change CiviCase menu order

### DIFF
--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -186,19 +186,6 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
   }
 
   /**
-   * Swaps 'Manage Cases' with 'Find Cases' menu weight.
-   * This upgrade should be executed only once so it's not added to install
-   * method.
-   *
-   * @return boolean
-   */
-  public function upgrade_0003() {
-    $this->swapCaseMenuItems();
-
-    return TRUE;
-  }
-
-  /**
    * Returns an array containing Case menu item for specified name.
    * Returns NULL if menu item is not found.
    *

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -374,25 +374,25 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
    * and 'Manage Cases' menu items.
    */
   private function swapCaseMenuItems() {
-    $findCasesItem = $this->getCaseMenuItem('Find Cases');
-    $manageCasesItem = $this->getCaseMenuItem('Manage Cases');
+    $findCasesMenuItem = $this->getCaseMenuItem('Find Cases');
+    $manageCasesMenuItem = $this->getCaseMenuItem('Manage Cases');
 
-    if (!$findCasesItem || !$manageCasesItem) {
+    if (!$findCasesMenuItem || !$manageCasesMenuItem) {
       return TRUE;
     }
 
     // Updating 'Find Cases' menu item.
     civicrm_api3('Navigation', 'create', array(
-      'id' => $findCasesItem['id'],
-      'weight' => !empty($manageCasesItem['weight']) ? $manageCasesItem['weight'] : NULL,
-      'has_separator' => $manageCasesItem['has_separator'],
+      'id' => $findCasesMenuItem['id'],
+      'weight' => !empty($manageCasesMenuItem['weight']) ? $manageCasesMenuItem['weight'] : NULL,
+      'has_separator' => $manageCasesMenuItem['has_separator'],
     ));
 
     // Updating 'Manage Cases' menu item.
     civicrm_api3('Navigation', 'create', array(
-      'id' => $manageCasesItem['id'],
-      'weight' => !empty($findCasesItem['weight']) ? $findCasesItem['weight'] : NULL,
-      'has_separator' => $findCasesItem['has_separator'],
+      'id' => $manageCasesMenuItem['id'],
+      'weight' => !empty($findCasesMenuItem['weight']) ? $findCasesMenuItem['weight'] : NULL,
+      'has_separator' => $findCasesMenuItem['has_separator'],
     ));
 
     CRM_Core_BAO_Navigation::resetNavigation();

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -163,21 +163,26 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
       Civi::settings()->set('recordGeneratedLetters', 'combined-attached');
     }
 
-    $this->upgrade_0001();
+    $this->createManageCasesMenuItem();
     $this->upgrade_0002();
   }
 
-  public function upgrade_0001() {
+  /**
+   * Creates 'Manage Cases' menu item for Cases navigation.
+   */
+  private function createManageCasesMenuItem() {
     $this->addNav(array(
       'label' => ts('Manage Cases', array('domain' => 'org.civicrm.civicase')),
-      'name' => 'manage_cases',
+      'name' => 'Manage Cases',
       'url' => 'civicrm/case/a/#/case/list',
       'permission' => 'access my cases and activities,access all cases and activities',
       'operator' => 'OR',
       'separator' => 0,
       'parent_name' => 'Cases',
     ));
+
     CRM_Core_BAO_Navigation::resetNavigation();
+
     return TRUE;
   }
 

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -164,7 +164,6 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     }
 
     $this->createManageCasesMenuItem();
-    $this->upgrade_0002();
   }
 
   /**
@@ -182,24 +181,6 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     ));
 
     CRM_Core_BAO_Navigation::resetNavigation();
-
-    return TRUE;
-  }
-
-  /**
-   * Renames 'manage_cases' to 'Manage Cases' menu item.
-   *
-   * @return boolean
-   */
-  public function upgrade_0002() {
-    $manageCasesItem = $this->getCaseMenuItem('manage_cases');
-
-    if (!empty($manageCasesItem)) {
-      civicrm_api3('Navigation', 'create', array(
-        'id' => $manageCasesItem['id'],
-        'name' => 'Manage Cases',
-      ));
-    }
 
     return TRUE;
   }

--- a/CRM/Civicase/Upgrader.php
+++ b/CRM/Civicase/Upgrader.php
@@ -186,29 +186,6 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
   }
 
   /**
-   * Returns an array containing Case menu item for specified name.
-   * Returns NULL if menu item is not found.
-   *
-   * @param string $name
-   *
-   * @return array|NULL
-   */
-  private function getCaseMenuItem($name) {
-    $result = civicrm_api3('Navigation', 'get', array(
-      'sequential' => 1,
-      'parent_id' => 'Cases',
-      'name' => $name,
-      'options' => array('limit' => 1),
-    ));
-
-    if (empty($result['id'])) {
-      return NULL;
-    }
-
-    return $result['values'][0];
-  }
-
-  /**
    * Tasks to perform after the module is installed.
    */
   public function postInstall() {
@@ -396,6 +373,29 @@ class CRM_Civicase_Upgrader extends CRM_Civicase_Upgrader_Base {
     ));
 
     CRM_Core_BAO_Navigation::resetNavigation();
+  }
+
+  /**
+   * Returns an array containing Case menu item for specified name.
+   * Returns NULL if menu item is not found.
+   *
+   * @param string $name
+   *
+   * @return array|NULL
+   */
+  private function getCaseMenuItem($name) {
+    $result = civicrm_api3('Navigation', 'get', array(
+      'sequential' => 1,
+      'parent_id' => 'Cases',
+      'name' => $name,
+      'options' => array('limit' => 1),
+    ));
+
+    if (empty($result['id'])) {
+      return NULL;
+    }
+
+    return $result['values'][0];
   }
 
   /**


### PR DESCRIPTION
- Changing 'manage_cases' menu item name to 'Manage Cases'.
- Swapping 'Find Cases' and 'Manage Cases' menu items ('weight' and 'has_separator' values) when disabling / enabling the extension.
- Removing upgrade methods.

Cases menu with CiviCase extension disabled:
![cases-menu-with-civicase-disabled](https://user-images.githubusercontent.com/8986209/31952443-e78fc1bc-b8e0-11e7-8168-8ffe69472bee.png)

Cases menu with CiviCase extension enabled:
![cases-menu-with-civicase-enabled](https://user-images.githubusercontent.com/8986209/31952464-edd1a84c-b8e0-11e7-9e12-953455e0f497.png)
