### PR TITLE
HW-418: Styled snagging of sticky parts

### DIFF
--- a/ang/civicase/ActivityFilters.js
+++ b/ang/civicase/ActivityFilters.js
@@ -44,7 +44,8 @@
         });
 
         $actHeader.affix({offset: {top: $casePanelBody.offset().top - 73} })
-          .css('top', $civicrmMenu.height())
+          .css('top', $civicrmMenu.height() + 53)
+          .css('width',$('.act-feed-panel').css('width'))
           .on('affixed.bs.affix', function() {
             $actHeader.css('width',$('.act-feed-panel').css('width'));
             $actHeader.css('top', $civicrmMenu.height() + 53);
@@ -54,6 +55,7 @@
           });
         
         $actControls.affix({offset: {top: $casePanelBody.offset().top - 73} })
+          .css('width',$actHeader.css('width'))
           .on('affixed.bs.affix', function() {
             $actControls.css('width',$actHeader.css('width'));
             $actControls.css('top',$civicrmMenu.height() + $actHeader.height() + 53);
@@ -65,7 +67,7 @@
 
         $scope.$watchCollection('[filters, exposedFilters]', function(){
           $timeout(function() {
-            $actControls.css('top',$civicrmMenu.height() + $actHeader.height());
+            $actControls.css('top',$civicrmMenu.height() + $actHeader.height() + 53);
             $feedActivity.not('.cc-zero-w')
               .height($(window).height() - ($civicrmMenu.height() + $actHeader.height() + $actControls.height()))
               .css('top',$civicrmMenu.height() + $actHeader.height() + $actControls.height() + 53);

--- a/ang/civicase/View.js
+++ b/ang/civicase/View.js
@@ -316,7 +316,7 @@
 
           $caseNavigation.affix({
             offset: {
-              top: $casePanelBody.offset().top - 73
+              top: $casePanelBody.offset().top - 87
             }
           })
           .on('affixed.bs.affix', function() {

--- a/css/activityFeed.css
+++ b/css/activityFeed.css
@@ -323,7 +323,7 @@
 }
 #bootstrap-theme .act-feed-list-group .act-feed-inner .btn {
   border: none;
-  padding: 0;
+  padding: 0 5px;
 }
 #bootstrap-theme .act-feed-list-group .act-contacts div:not(.act-contacts-target):not(.btn-group) {
   min-width: 40%;
@@ -414,7 +414,7 @@
   max-width: 170px;
 }
 #bootstrap-theme div.act-feed-panel .act-list-controls .select2-container {
-  min-width: 220px;
+  min-width: 185px;
 }
 #bootstrap-theme .act-feed-list-group .act-list-controls.affix {
   margin: 0px;
@@ -518,6 +518,7 @@
   background-color: #fcfcfc;
 }
 #bootstrap-theme .activity-timeline .activity-item-menu.btn-group {
+  margin-right: -5px;
   margin-top: -10px;
 }
 #bootstrap-theme .activity-timeline .act-category-communication .activity-item-menu.btn-group {

--- a/css/caseView.css
+++ b/css/caseView.css
@@ -390,11 +390,11 @@
   position: absolute;
   top: 0;
   width: 18px;
-  z-index: 1;
 }
 #bootstrap-theme .civicase-view-next-activities:before {
   box-shadow: inset 36px 0 18px -36px rgba(49,40,40,0.25);
   left: 0;
+  z-index: 1;
 }
 #bootstrap-theme .civicase-view-next-activities:after {
   box-shadow: inset -36px 0 18px -36px rgba(49,40,40,0.25);


### PR DESCRIPTION
Description:
The PR fixes below points:
1. The category list has too much width
2. the clicking area of the activity card action buttons is too small
3. Sticky navigation on the dashboard jumps to hug the top screen
4. shadow in next up section is over the timeline dropdown list
5. Caselist activity tab filters bar sticks before the tabset does
6. When stick the Caselist activity tab filters bar and click on other tabs, then switch back. the filters bar is over the tabset
7. The collapsed column bar is shorter than the case details column

**Before:**
<img width="1108" alt="screen shot 2017-10-30 at 18 23 14" src="https://user-images.githubusercontent.com/26058635/32221944-719fa332-be5d-11e7-9790-63afa4db7780.png">

_Wrong jump_
<img width="1280" alt="screen shot 2017-10-30 at 18 33 11" src="https://user-images.githubusercontent.com/26058635/32221946-729d9e06-be5d-11e7-99ce-90d53d7c3512.png">

_Wrong top position & width_
<img width="1258" alt="screen shot 2017-10-30 at 18 37 22 1" src="https://user-images.githubusercontent.com/26058635/32221952-753bbe86-be5d-11e7-89d5-a1b1b3dd66d7.png">
<img width="1280" alt="screen shot 2017-10-30 at 18 38 39" src="https://user-images.githubusercontent.com/26058635/32221955-770130f2-be5d-11e7-91c2-c6688904cdbd.png">

_Wrong time line z-index_
<img width="374" alt="screen shot 2017-10-30 at 18 35 30 1" src="https://user-images.githubusercontent.com/26058635/32222331-db0c268c-be5e-11e7-8d81-3b31b916369e.png">

**After:**
![after-2](https://user-images.githubusercontent.com/26058635/32222335-dd6a4fc6-be5e-11e7-865f-3f4bbb2a69f6.png)
![after](https://user-images.githubusercontent.com/26058635/32222343-e68f1c94-be5e-11e7-87d2-60d0b1877898.png)
