### PR TITLE
CRM-21406 - Add export cases action

### DIFF
--- a/ang/civicase.ang.php
+++ b/ang/civicase.ang.php
@@ -146,6 +146,11 @@ $options['caseActions'] = array(
     'icon' => 'fa-file-pdf-o',
   ),
   array(
+    'title' => ts('Export Cases'),
+    'action' => 'exportCases(cases)',
+    'icon' => 'fa-file-excel-o',
+  ),
+  array(
     'title' => ts('Link Cases'),
     'action' => 'linkCases(cases[0])',
     'number' => 1,

--- a/ang/civicase/Actions.js
+++ b/ang/civicase/Actions.js
@@ -218,6 +218,19 @@
               return popupPath;
             },
 
+            exportCases: function(cases) {
+              var caseIds = _.collect(cases, 'id');
+              var popupPath = {
+                path: 'civicrm/export/standalone',
+                query: {
+                  reset: 1,
+                  entity: 'Case',
+                  id: caseIds.join()
+                }
+              };
+              return popupPath;
+            },
+
             linkCases: function(case1, case2) {
               var activityTypes = CRM.civicase.activityTypes,
                 link = {


### PR DESCRIPTION
This depends on https://github.com/civicrm/civicrm-core/pull/11254

@guanhuan @mukeshcompucorp there is a css bug in ShorDitch which is causing this to not display properly. The circled text is missing, (I manipulated css in my console to show it). The offending line is

    .crm-container.ui-dialog .ui-dialog-content h3 {
      display: none;
    }

I consider that to be a very bad css rule. I would advise whoever wrote it to go back to the drawing board and find a different solution to whatever problem they were trying to solve.

![exportcases](https://user-images.githubusercontent.com/2874912/32552272-6120048e-c461-11e7-94f4-e6e036d63ecd.png)
