### PR TITLE
BASW-124: Fix Statuses Block UI In Cases Dashboard When There Are Many Case Statuses

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -1,5 +1,6 @@
 #bootstrap-theme .dashboard-case-summary-wrapper {
   padding: 0 20px 0 0;
+  overflow-x: auto;
 }
 #bootstrap-theme .dashboard-case-summary-wrapper.show-summary-breakdown {
   background: #FFFFFF;


### PR DESCRIPTION
## Overview ##
When there are more case statuses such that it exceeds the width of the dashboard, the case summary block breaks UI layout.

## Fix ##
I have added a css overflow to this block such that it doesnt break UI and stays within the overall dashboard layout.