### PR TITLE
C51-41: Add download all activity files page link

### DIFF
--- a/CRM/Civicase/Page/ActivityFiles.php
+++ b/CRM/Civicase/Page/ActivityFiles.php
@@ -109,7 +109,9 @@ class CRM_Civicase_Page_ActivityFiles {
     $zip->open($zipFullPath, $mode);
 
     foreach ($filePaths as $filePath) {
-      $zip->addFile($filePath, substr($filePath, strrpos($filePath, '/') + 1));
+      $fileName = basename($filePath);
+
+      $zip->addFile($filePath, $fileName);
     }
 
     $zip->close();

--- a/CRM/Civicase/Page/ActivityFiles.php
+++ b/CRM/Civicase/Page/ActivityFiles.php
@@ -7,7 +7,6 @@ class CRM_Civicase_Page_ActivityFiles {
    */
   public static function downloadAll() {
     $activityId = CRM_Utils_Array::value('activity_id', $_GET);
-
     self::validateActivityId($activityId);
 
     $zipName = 'activity-' . $activityId . '-files.zip';
@@ -86,14 +85,10 @@ class CRM_Civicase_Page_ActivityFiles {
    */
   private static function downloadZipFile($zipFullPath) {
     $zipName = basename($zipFullPath);
+    $fileResource = NULL;
 
-    header('Content-Type: application/zip');
-    header('Content-disposition: attachment; filename=' . $zipName);
-    header('Content-Length: ' . filesize($zipFullPath));
-
-    readfile($zipFullPath);
-
-    CRM_Utils_System::civiExit();
+    readfile($zipFullPath, FALSE, $fileResource);
+    CRM_Utils_System::download($zipName, 'application/zip', $fileResource);
   }
 
 }

--- a/CRM/Civicase/Page/ActivityFiles.php
+++ b/CRM/Civicase/Page/ActivityFiles.php
@@ -1,0 +1,99 @@
+<?php
+
+class CRM_Civicase_Page_ActivityFiles {
+
+  /**
+   * Download all activity files contained in a single zip file.
+   */
+  public static function downloadAll() {
+    $activityId = CRM_Utils_Array::value('activity_id', $_GET);
+
+    self::validateActivityId($activityId);
+
+    $zipName = 'activity-' . $activityId . '-files.zip';
+    $zipDestination = self::getDestinationPath();
+    $zipFullPath = $zipDestination . '/' . $zipName;
+    $files = self::getActivityFilePaths($activityId);
+
+    self::createOrUpdateZipFile($zipFullPath, $files);
+    self::downloadZipFile($zipFullPath);
+  }
+
+  /**
+   * Validates that the activity id was provided. If not, it returns a 404 status code.
+   *
+   * @param string|null $activityId
+   */
+  private static function validateActivityId($activityId) {
+    if (empty($activityId)) {
+      http_response_code(404);
+      CRM_Utils_System::civiExit();
+    }
+  }
+
+  /**
+   * Returns the destination path for the zip file.
+   *
+   * @return string
+   */
+  private static function getDestinationPath() {
+    $config = CRM_Core_Config::singleton();
+
+    return $config->customFileUploadDir;
+  }
+
+  /**
+   * Returns a list of file paths that are part of a given activity.
+   *
+   * @param int $activityId
+   *
+   * @return array
+   */
+  private static function getActivityFilePaths($activityId) {
+    $filePaths = [];
+    $activityFiles = CRM_Core_BAO_File::getEntityFile('civicrm_activity', $activityId);
+
+    foreach ($activityFiles as $activityFile) {
+      $filePaths[] = $activityFile['fullPath'];
+    }
+
+    return $filePaths;
+  }
+
+  /**
+   * Creates or updates a zip file at the given path and containing the given files.
+   *
+   * @param string $zipFullPath
+   * @param array $filePaths
+   */
+  private static function createOrUpdateZipFile($zipFullPath, $filePaths) {
+    $zipName = basename($zipFullPath);
+    $zip = new ZipArchive();
+    $mode = ZipArchive::CREATE | ZipArchive::OVERWRITE;
+    $zip->open($zipFullPath, $mode);
+
+    foreach ($filePaths as $filePath) {
+      $zip->addFile($filePath, substr($filePath, strrpos($filePath, '/') + 1));
+    }
+
+    $zip->close();
+  }
+
+  /**
+   * Setups the given zip file so it can be downloaded by the browser.
+   *
+   * @param string $zipFullPath
+   */
+  private static function downloadZipFile($zipFullPath) {
+    $zipName = basename($zipFullPath);
+
+    header('Content-Type: application/zip');
+    header('Content-disposition: attachment; filename=' . $zipName);
+    header('Content-Length: ' . filesize($zipFullPath));
+
+    readfile($zipFullPath);
+
+    CRM_Utils_System::civiExit();
+  }
+
+}

--- a/xml/Menu/civicase.xml
+++ b/xml/Menu/civicase.xml
@@ -17,4 +17,11 @@
     <title>ContactActivityTab</title>
     <access_arguments>access CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/case/activity/download-all-files</path>
+    <page_callback>CRM_Civicase_Page_ActivityFiles::downloadAll</page_callback>
+    <title>Activity Files</title>
+    <access_callback>1</access_callback>
+    <is_public>true</is_public>
+  </item>
 </menu>

--- a/xml/Menu/civicase.xml
+++ b/xml/Menu/civicase.xml
@@ -21,7 +21,6 @@
     <path>civicrm/case/activity/download-all-files</path>
     <page_callback>CRM_Civicase_Page_ActivityFiles::downloadAll</page_callback>
     <title>Activity Files</title>
-    <access_callback>1</access_callback>
-    <is_public>true</is_public>
+    <access_arguments>access all cases and activities;access my cases and activities</access_arguments>
   </item>
 </menu>


### PR DESCRIPTION
This PR adds a page link that allows downloading all the files associated with an Activity in a single zip file.

## How it works

![pr-after](https://user-images.githubusercontent.com/1642119/45038045-6b4d1c80-b02e-11e8-9626-bb5b0e0e780a.gif)

## Technical details

A new page was added that retrieves the files for an activity and groups them in a single zip file that can be downloaded by the users.

The structure of the class is divided into the following units:

### Validating that the activity id was provided

```php
 private static function validateActivityId($activityId) {
    if (empty($activityId)) {
      http_response_code(404);
      CRM_Utils_System::civiExit();
    }
  }
```

### Get the destination path for the zip file

```php
  private static function getDestinationPath() {
    $config = CRM_Core_Config::singleton();

    return $config->customFileUploadDir;
  }
```

### Getting the files associated to the activity

```php
  private static function getActivityFilePaths($activityId) {
    $filePaths = [];
    $activityFiles = CRM_Core_BAO_File::getEntityFile('civicrm_activity', $activityId);

    foreach ($activityFiles as $activityFile) {
      $filePaths[] = $activityFile['fullPath'];
    }

    return $filePaths;
  }
```

### Creating the zip file

```php
  private static function createOrUpdateZipFile($zipFullPath, $filePaths) {
    $zipName = basename($zipFullPath);
    $zip = new ZipArchive();
    $mode = ZipArchive::CREATE | ZipArchive::OVERWRITE;
    $zip->open($zipFullPath, $mode);

    foreach ($filePaths as $filePath) {
      $zip->addFile($filePath, substr($filePath, strrpos($filePath, '/') + 1));
    }

    $zip->close();
  }
```

### Downloading the newly created zip file

```php
  private static function downloadZipFile($zipFullPath) {
    $zipName = basename($zipFullPath);

    header('Content-Type: application/zip');
    header('Content-disposition: attachment; filename=' . $zipName);
    header('Content-Length: ' . filesize($zipFullPath));

    readfile($zipFullPath);

    CRM_Utils_System::civiExit();
  }
```

### Zip link

The final orchestration to download the zip file is this:

```php
  public static function downloadAll() {
    $activityId = CRM_Utils_Array::value('activity_id', $_GET);

    self::validateActivityId($activityId);

    $zipName = 'activity-' . $activityId . '-files.zip';
    $zipDestination = self::getDestinationPath();
    $zipFullPath = $zipDestination . '/' . $zipName;
    $files = self::getActivityFilePaths($activityId);

    self::createOrUpdateZipFile($zipFullPath, $files);
    self::downloadZipFile($zipFullPath);
  }
```